### PR TITLE
Adding Microsoft ODBC Drivers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ENV RSTUDIO=no
 ENV SHINY=no
 ENV H2O=no
 
+# DELETE
+RUN echo ""
+
 # Install base utility packages
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,6 @@ ENV RSTUDIO=no
 ENV SHINY=no
 ENV H2O=no
 
-# DELETE
-RUN echo ""
-
 # Install base utility packages
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV H2O=no
 # Install base utility packages
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get update && \
-    apt-get dist-upgrade
+    apt-get dist-upgrade -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install tzdata apt-utils
 RUN ln -fs /usr/share/zoneinfo/Africa/Johannesburg /etc/localtime
 RUN dpkg-reconfigure --frontend noninteractive tzdata

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ None of these environments are configured to spin up at runtime. Rather, use env
 -p 8000:8000 \ # jupyterhub
 -p 8787:8787 \ # rstudio
 -p 3838:3838 \ # shiny
-cityofcapetown/docker_datascience-1
+cityofcapetown/docker_datascience
 ```
 
 **Note:** There is no flag to spin up h2o, because the h2o jar wants you to specify RAM allocation at runtime. So rather spin it up from an R or python script.
@@ -58,5 +58,5 @@ docker run -it --rm \
 -p 54321:54321 \
 -p 54322:54321 \
 -e GIT_REPO=https://github.com/riazarbi/workspace_template.git \
-cityofcapetown/docker_datascience-1
+cityofcapetown/docker_datascience
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To change the defaults, change the environment variables `$NEWUSER` and `$PASSWD
 docker run -rm \
 -e NEWUSER=neweruser \
 -e PASSWD=newpassword \
-cityofcapetown/docker_datascience-1
+cityofcapetown/docker_datascience
 ```
 
 None of these environments are configured to spin up at runtime. Rather, use enviroment flags to enable services. You'll need to map the ports as well. For instance -

--- a/apt_additions.sh
+++ b/apt_additions.sh
@@ -24,3 +24,16 @@ apt-get install -y \
 default-jre \
 default-jdk && \
 apt-get clean
+
+# INSTALL ODBC
+# More specifically, the Microsoft driver
+
+DEBIAN_FRONTEND=noninteractive \
+wget https://packages.microsoft.com/keys/microsoft.asc -O microsoft.asc && \
+apt-key add microsoft.asc && \
+wget https://packages.microsoft.com/config/ubuntu/18.04/prod.list -O prod.list && \
+cp prod.list /etc/apt/sources.list.d/mssql-release.list && \
+apt-get update && \
+ACCEPT_EULA=Y apt-get install -y \
+msodbcsql17 \
+unixodbc-dev

--- a/python_additions.sh
+++ b/python_additions.sh
@@ -12,6 +12,7 @@ python3 -m pip install scipy
 python3 -m pip install sklearn
 python3 -m pip install ipyleaflet
 python3 -m pip install geojson-utils
+python3 -m pip install pyodbc
 
 # Non-standard packages go here
 jupyter nbextension enable --py --sys-prefix ipyleaflet


### PR DESCRIPTION
# Overview
What it says on the tin - adding the drivers needed to talk to Microsoft SQL Server, as well as the Python bindings.

# Testing
1. Did a docker build: `docker build .`, eventually got:
```
 ---> 233fd5a4a54c
Successfully built 233fd5a4a54c
```
2. Going to tag it: `docker image tag 233fd5a4a54c ds-test-build-2`
3. Now, running it: `docker run -it --rm -e NEWUSER=neweruser -e PASSWD=newpassword -e JUPYTER=yes -e RSTUDIO=yes -e SHINY=yes -p 8000:8000 -p 8787:8787 -p 3838:3838 -p 54321:54321 -p 54322:54321 -e GIT_REPO=https://github.com/riazarbi/workspace_template.git ds-test-build-2`
4. Checking that the drivers are present: `python3 -c "import pyodbc; print(pyodbc.drivers())"`, got `['ODBC Driver 17 for SQL Server']`
5. Checking that we can talk to a SQL server:
```python
conn = pyodbc.connect("DRIVER={ODBC Driver 17 for SQL Server};" +
                      "SERVER=CDCTRDP\\CDCTRDP,1435;"  +
                      "DATABASE=UGMS2017;" +
                      "UID=ugmsuser;" +
                      "PWD=ugms@user")
```
Step (5) times out with `OperationalError: ('HYT00', '[HYT00] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired (0) (SQLDriverConnect)')`. I'm able to connect from the Docker host, so I suspect this is a container configuration issue? Any idea of how to allow egress on port 1435?