### PR TITLE
adding jupyter stack python libraries

### DIFF
--- a/python_additions.sh
+++ b/python_additions.sh
@@ -14,8 +14,31 @@ python3 -m pip install ipyleaflet
 python3 -m pip install geojson-utils
 python3 -m pip install pyodbc
 python3 -m pip install bs4
-python3 -m pip install pandas, setuptools, Xlsxwriter, openpyxl, xlrd, pyexcel
 
+# ADDING JUPYTER DOCKER STACKS PYTHON PACKAGES: SCIPY NOTEBOOK
+python3 -m pip install \
+    pandas, \
+    numexpr, \
+    matplotlib, \
+    scipy, \
+    seaborn, \
+    scikit-learn, \
+    scikit-image, \
+    sympy, \
+    cython, \
+    patsy, \
+    statsmodels, \
+    cloudpickle, \
+    dill, \
+    numba, \
+    bokeh, \
+    sqlalchemy, \
+    hdf5, \
+    h5py, \
+    vincent, \
+    beautifulsoup4, \
+    protobuf, \
+    xlrd
 
 # Non-standard packages go here
 jupyter nbextension enable --py --sys-prefix ipyleaflet


### PR DESCRIPTION
# Scope
This branch aims to systematically add every python package to this docker build that appears in the jupyter docker stack repostories.

# Possibly issues
* Jupyter docker stacks use the conda environmet; we use pypi. So package names may not translate directly leading to build failures
* Jupyter docker stacks specify explicit verison numbers for each package which limits broken dependencies. We don't which can cause problems.