### PR TITLE
All services behind NGINX proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,10 +113,23 @@ COPY apt_additions.sh .
 COPY R_additions.R .
 COPY python_additions.sh .
 
-RUN bash apt_additions.sh
-RUN bash python_additions.sh
-RUN Rscript R_additions.R
+#RUN bash apt_additions.sh
+#RUN bash python_additions.sh
+#RUN Rscript R_additions.R
 
+# SET UP NGINX
+EXPOSE 80
+EXPOSE 443
+RUN apt-get update && \
+    apt-get install nginx -y && \
+    apt-get clean
+COPY nginx.conf /
+COPY default /
+RUN mv nginx.conf /etc/nginx/nginx.conf
+RUN mv default /etc/nginx/sites-available/default
+RUN sed -i "/c.JupyterHub.base_url/c\c.JupyterHub.base_url = '/jupyter'" /etc/jupyterhub/jupyterhub_config.py
+
+# STARTUP SCRIPT
 # Install tini to run entrypoint command
 ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
@@ -129,3 +142,5 @@ RUN chmod +x /run.sh
 
 # Run startup script on runtime
 CMD ["/bin/bash", "./run.sh"]
+
+#c.JupyterHub.base_url = '/jupyter'

--- a/default
+++ b/default
@@ -1,0 +1,148 @@
+##
+# You should look at the following URL's in order to grasp a solid understanding
+# of Nginx configuration files in order to fully unleash the power of Nginx.
+# https://www.nginx.com/resources/wiki/start/
+# https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/
+# https://wiki.debian.org/Nginx/DirectoryStructure
+#
+# In most cases, administrators will remove this file from sites-enabled/ and
+# leave it as reference inside of sites-available where it will continue to be
+# updated by the nginx packaging team.
+#
+# This file will automatically load configuration files provided by other
+# applications, such as Drupal or Wordpress. These applications will be made
+# available underneath a path with that package name, such as /drupal8.
+#
+# Please see /usr/share/doc/nginx-doc/examples/ for more detailed examples.
+##
+
+# Default server configuration
+#
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	# SSL configuration
+	#
+	# listen 443 ssl default_server;
+	# listen [::]:443 ssl default_server;
+	#
+	# Note: You should disable gzip for SSL traffic.
+	# See: https://bugs.debian.org/773332
+	#
+	
+
+	root /var/www/html;
+
+	# Add index.php to the list if you are using PHP
+	index index.html index.htm index.nginx-debian.html;
+
+	server_name _;
+
+	#location / {
+		# First attempt to serve request as file, then
+		# as directory, then fall back to displaying a 404.
+		#try_files $uri $uri/ =404;
+         #       proxy_pass http://localhost:3838;
+         #       proxy_redirect http://localhost:3838 $scheme://$host/;
+         #       proxy_http_version 1.1;
+         #       proxy_set_header Upgrade $http_upgrade;
+         #       proxy_set_header Connection $connection_upgrade;
+         #       proxy_read_timeout 20d;
+	#}
+
+
+        location /jupyter/ {
+                proxy_pass http://localhost:8000;
+                proxy_set_header X-Real_IP $remote_addr;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Nginx-Proxy true;
+                
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+        }                
+
+        location ~* /(user/[^/]*)/(api/kernels/[^/]+/channels|terminals/websocket)/? {
+            proxy_pass http://localhost:8000;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-NginX-Proxy true;
+
+            # WebSocket support
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 86400;
+
+        }
+
+
+
+        location /rstudio/ {
+                rewrite ^/rstudio/(.*)$ /$1 break;
+                proxy_pass http://localhost:8787;
+                proxy_redirect http://localhost:8787/ $scheme://$host/rstudio/;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $connection_upgrade;
+                proxy_read_timeout 20d;
+        }
+
+
+
+
+        # WORKING
+#        location /rstudio/ {
+#                rewrite ^/rstudio/(.*)$ /$1 break;
+#                proxy_pass http://localhost:8787;
+#                proxy_redirect http://localhost:8787/ $scheme://$host/rstudio/;
+#                proxy_http_version 1.1;
+#                proxy_set_header Upgrade $http_upgrade;
+#                proxy_set_header Connection $connection_upgrade;
+#                proxy_read_timeout 20d;
+#        }
+
+
+
+
+	# pass PHP scripts to FastCGI server
+	#
+	#location ~ \.php$ {
+	#	include snippets/fastcgi-php.conf;
+	#
+	#	# With php-fpm (or other unix sockets):
+	#	fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+	#	# With php-cgi (or other tcp sockets):
+	#	fastcgi_pass 127.0.0.1:9000;
+	#}
+
+	# deny access to .htaccess files, if Apache's document root
+	# concurs with nginx's one
+	#
+	#location ~ /\.ht {
+	#	deny all;
+	#}
+}
+
+
+# Virtual Host configuration for example.com
+#
+# You can move that to a different file under sites-available/ and symlink that
+# to sites-enabled/ to enable it.
+#
+#server {
+#	listen 80;
+#	listen [::]:80;
+#
+#	server_name example.com;
+#
+#	root /var/www/example.com;
+#	index index.html;
+#
+#	location / {
+#		try_files $uri $uri/ =404;
+#	}
+#}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,89 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+        map $http_upgrade $connection_upgrade {
+            default upgrade;
+            ''      close;
+        }
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+	gzip_disable "msie6";
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}
+
+
+#mail {
+#	# See sample authentication script at:
+#	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
+# 
+#	# auth_http localhost/auth.php;
+#	# pop3_capabilities "TOP" "USER";
+#	# imap_capabilities "IMAP4rev1" "UIDPLUS";
+# 
+#	server {
+#		listen     localhost:110;
+#		protocol   pop3;
+#		proxy      on;
+#	}
+# 
+#	server {
+#		listen     localhost:143;
+#		protocol   imap;
+#		proxy      on;
+#	}
+#}

--- a/run.sh
+++ b/run.sh
@@ -13,11 +13,25 @@ chown -R $NEWUSER:$NEWUSER /home/$NEWUSER
 # Make the new user an admin user of Jupyterhub
 sed -i "/c.Authenticator.admin_users/c\c.Authenticator.admin_users = {'\$NEWUSER\'}" /etc/jupyterhub/jupyterhub_config.py
 
+# Start nginx
+nginx &
+
+# Use this code block in production
 # Run shiny
-if [[ $SHINY = "yes" ]]; then shiny-server &> /dev/null & fi
+#if [[ $SHINY = "yes" ]]; then shiny-server &> /dev/null & fi
 # Run Rstudio
-if [[ $RSTUDIO = "yes" ]]; then rstudio-server start &> /dev/null & fi
+#if [[ $RSTUDIO = "yes" ]]; then rstudio-server start &> /dev/null & fi
 # Run jupyter
-if [[ $JUPYTER = "yes" ]]; then jupyterhub -f /etc/jupyterhub/jupyterhub_config.py &> /dev/null & fi
+#if [[ $JUPYTER = "yes" ]]; then jupyterhub -f /etc/jupyterhub/jupyterhub_config.py &> /dev/null & fi
 # Drop privileges to sudo user and enter bash
-read -n 1 -s -r -p "Press any key to quit...  `echo $'\n \n \n> '`"
+#read -n 1 -s -r -p "Press any key to quit...  `echo $'\n \n \n> '`"
+
+# Use this code block in testing
+# Run shiny
+shiny-server &
+# Run Rstudio
+rstudio-server start &
+# Run jupyter
+jupyterhub -f /etc/jupyterhub/jupyterhub_config.py
+
+


### PR DESCRIPTION
# Potential

It would be pretty cool to spin up a container with name containername and have the following urls work magically: 

http://containername.domain/jupyter
http://containername.domain/rstudio
http://containername.domain/shiny

**Especially** since we could name containers after git repos. Because then we would intuitively know how to find the compute related to the repo. 

We could integrate this with the git clone functionality of our docker image and the minio bucket so that the container is given : 

1) A nice URL
2) A folder in home with the repo cloned
3) Data from the right bucket ready to go an loaded in memory


# Status

This works at present for Jupyter and RStudio. If you spin up a container with -p 80:80, then http://localhost/jupyter points to jupyter and http://localhost/rstudio points to rstudio. 

I haven't done shiny yet because of time constraints, but I would be happy to.

# Problems

If you map the container to a non-standard port (ie -p 8080:80), then it stops working because both jupyter and rstudio's nginx configs strip the port back down to 80. That is to say, http://localhost:8080/jupyter redirects to http://localhost/rstudio, which obviously doesn't work.

# Addressing the issue

This problem can be quite elegantly dealt with by using the jwilder/nginx-proxy docker image, run with the command 

`sudo docker run -d --restart=always -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy`

Once the jwilder container is running, you can run the datascience container like so - 

`sudo docker run -it --rm -e VIRTUAL_HOST=containername.localhost -e JUPYTER=yes -e RSTUDIO=yes -e SHINY=yes ...blah blah`

This will result in accessible environments at http://containername.localhost/jupyter and http://containername.localhost/rstudio

# Problems arising from addressing the issue

So the solution above is fine for localhost, but doesn't work with raw ip addresses (such as 127.0.0.1 or 192.168.8.103). These ip addresses do work in conjunction with a wildcard dns IP service, such as xip.io. 

So this works:

`sudo docker run -it --rm -e VIRTUAL_HOST=~^container\..*\.xip\.io -e JUPYTER=yes -e RSTUDIO=yes -e SHINY=yes ds`

And results in service being accessible at, for instance, 

http://container.127.0.0.1.xip.io/jupyter/hub/login

or 

http://container.192.168.8.105.xip.io/jupyter/hub/login

But we can't use this in the corporate environment because we can't access the xip.io domain resolution service.


