### PR TITLE
Make git clone optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ EXPOSE 1433
 ENV NEWUSER=newuser
 ENV PASSWD=password
 ENV SUDO=no
-ENV GITREPO=https://github.com/riazarbi/workspace_template.git
+ENV GITREPO=no
 ENV JUPYTER=no
 ENV RSTUDIO=no
 ENV SHINY=no

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ COPY python_additions.sh .
 
 RUN bash apt_additions.sh
 RUN bash python_additions.sh
-RUN Rscript R_additions.R
+#RUN Rscript R_additions.R
 
 # Install tini to run entrypoint command
 ENV TINI_VERSION v0.18.0

--- a/run.sh
+++ b/run.sh
@@ -5,10 +5,12 @@ echo $NEWUSER:$PASSWD | chpasswd
 # Grant new user sudo if ENV says so
 if [[ $SUDO = "yes" ]]; then adduser $NEWUSER sudo ; fi
 
-# Clone a project git repo into the /home/$NEWUSER folder
-cd /home/$NEWUSER && /usr/bin/git clone $GITREPO
-# Sort out permissions for git git folder
+# Clone a project git repo into the /home/$NEWUSER folder if env var has been changed
+if [[ $GITREPO != "no" ]]; then cd /home/$NEWUSER && /usr/bin/git clone $GITREPO ; fi
+
+# Sort out permissions for home folder
 chown -R $NEWUSER:$NEWUSER /home/$NEWUSER
+chmod -R 770 /home/$NEWUSER
 
 # Make the new user an admin user of Jupyterhub
 sed -i "/c.Authenticator.admin_users/c\c.Authenticator.admin_users = {'\$NEWUSER\'}" /etc/jupyterhub/jupyterhub_config.py


### PR DESCRIPTION
On run this image automatically clones in the workspace template, but it is rarely used. This branch sets the GITREPO option to 'no', but accepts an env variable at run that will result in a clone if desired.