### PR TITLE
Coct auto git clone

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -75,5 +75,6 @@ ENV GITEMAIL ""
 ENV SUDO "no"
 ENV VIRTUAL_PATH /
 ENV VIRTUAL_HOST "localhost"
+ENV COCT_CONTAINER "yes"
 
 CMD ["/bin/bash", "./run.sh"]

--- a/base/run.sh
+++ b/base/run.sh
@@ -14,6 +14,15 @@ if [[ $SUDO = "yes" ]]; then
   adduser $NEWUSER sudo 
 fi
 
+# Clone common repos into home directory
+if [[ $COCT_CONTAINER == "yes" ]]; then
+  echo "cloning in CoCT standard repos"...
+  cd /home/$NEWUSER && /usr/bin/git clone https://ds1.capetown.gov.za/ds_gitlab/OPM/db-utils.git
+  # to do - create a samples/tutorials repo and clone it in
+  # to do - create a user manual repo and clone it in
+fi
+
+
 # Clone a project git repo into the /home/$NEWUSER folder
 if [[ $GITREPO != "" ]]; then
   echo cloning $GITREPO...


### PR DESCRIPTION
Make the image automatically clone in git repos that are important / used all the time.

Currently, this branch has an ENV variable `COCT_CONTAINER` set to `yes` as default. When is is set to `yes`, `run.sh` will clone in `db-utils`. Suggest we develop and add a `tutorials` repo and a `documentation` repo as well.

Opinion: we should think about what parts of this image are CoCT-specific / opinionated (the VIRTUAL_PATH stuff comes to mind) and wrap them all in a COCT_CONTAINER switch so that others can disable them if they want.