### PR TITLE
Adding Runtime Oracle ODBC driver setup

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -18,7 +18,9 @@ RUN DEBIAN_FRONTEND=noninteractive \
   apt-utils \
   git \
   sudo \
-  locales
+  locales \
+  dnsutils \
+  alien
 
 # Setting the timezone
 ENV TZ="Africa/Johannesburg"

--- a/base/python/Dockerfile
+++ b/base/python/Dockerfile
@@ -21,7 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
 # ODBC
 RUN DEBIAN_FRONTEND=noninteractive \
   apt-get update && \
-  apt-get install -y gnupg2 unixodbc-dev
+  apt-get install -y gnupg2 unixodbc-dev unixodbc-bin unixodbc libaio1
 
 # Microsoft driver
 RUN wget https://packages.microsoft.com/keys/microsoft.asc -O microsoft.asc && \
@@ -31,6 +31,10 @@ RUN wget https://packages.microsoft.com/keys/microsoft.asc -O microsoft.asc && \
   apt-get update && \
   ACCEPT_EULA=Y apt-get install -y \
   msodbcsql17
+
+# Oracle driver
+# This is installed at run time as it needs to fetch packages from the Edge Minio
+COPY oracle_odbc_setup.sh /run_scripts/
 
 # Python dependencies
 RUN DEBIAN_FRONTEND=noninteractive \

--- a/base/python/oracle_odbc_setup.sh
+++ b/base/python/oracle_odbc_setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+EDGE_LOCATION="ds2.capetown.gov.za"
+ORACLE_BUCKET_NAME="oracle-instantclient"
+INSTANCE_CLIENT="oracle-instantclient18.3-basic-18.3.0.0.0-1.x86_64"
+ODBC_DRIVER="oracle-instantclient18.3-odbc-18.3.0.0.0-1.x86_64"
+
+# Detecting whether we can get to the Minio Edge
+nslookup $EDGE_LOCATION
+
+if [ $? -eq 0 ]; then
+    # Getting Oracle client and ODBC driver
+    wget -q https://"$EDGE_LOCATION"/"$ORACLE_BUCKET_NAME"/"$INSTANCE_CLIENT".rpm --directory-prefix /tmp/
+    wget -q https://"$EDGE_LOCATION"/"$ORACLE_BUCKET_NAME"/"$ODBC_DRIVER".rpm --directory-prefix /tmp/
+
+    # Converting and installing the Oracle client
+    alien -i /tmp/"$INSTANCE_CLIENT".rpm
+    alien -i /tmp/"$ODBC_DRIVER".rpm
+
+    # Removing the RPM files
+    rm /tmp/"$INSTANCE_CLIENT".rpm
+    rm /tmp/"$ODBC_DRIVER".rpm
+
+    # Updating the environmental config
+    export LD_LIBRARY_PATH=/usr/lib/oracle/18.3/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+    ldconfig
+
+    # Updating the ODBC config file
+    echo -e "[Oracle Driver 18.3]\nDescription=Oracle Unicode driver\nDriver=/usr/lib/oracle/18.3/client64/lib/libsqora.so.18.1\nUsageCount=1\nFileUsage=1" \
+      >> /etc/odbcinst.ini
+
+else
+    echo "Could not resolve ds2.capetown.gov.za, not installing Oracle client"
+fi

--- a/base/run.sh
+++ b/base/run.sh
@@ -47,7 +47,7 @@ fi
 # RUN any startup scripts in the hook location
 for startup_script in $(ls /run_scripts); do
     echo "Running '$startup_script'...)"
-    timeout 60 /run_scripts/"$startup_script"
+    timeout 300 /run_scripts/"$startup_script"
 done
 
 # Start nginx

--- a/base/run.sh
+++ b/base/run.sh
@@ -47,7 +47,7 @@ fi
 # RUN any startup scripts in the hook location
 for startup_script in $(ls /run_scripts); do
     echo "Running '$startup_script'...)"
-    timeout 300 /run_scripts/"$startup_script"
+    timeout 300 ./run_scripts/"$startup_script"
 done
 
 # Start nginx


### PR DESCRIPTION
# Overview
Redo of #19 , rather doing this at runtime. The files are fetched from Minio edge, from a read-only bucket. I've used the existing run hook script mechanism (i.e. everything in `/run_scripts/` is run), as opposed to adding new.

One consideration is that the run scripts hook mechanism only works if the base `run.sh` CMD is used. I think we should consider splitting out at least some of `run.sh` into an entrypoint script, but I feel that is beyond the scope of this change.

# Testing
1. Built and ran bash in local version of Python docker image: `docker build . -t datascience:python-test` and `docker run --rm -it datascience:python-test bash`
2. Ran the oracle setup script: `/run_scripts/oracle_odbc_setup.sh`:
```
Server:		127.0.0.53
Address:	127.0.0.53#53

Non-authoritative answer:
Name:	ds2.capetown.gov.za
Address: 172.25.65.85
	dpkg --no-force-overwrite -i oracle-instantclient18.3-basic_18.3.0.0.0-2_amd64.deb
Selecting previously unselected package oracle-instantclient18.3-basic.
(Reading database ... 25896 files and directories currently installed.)
Preparing to unpack oracle-instantclient18.3-basic_18.3.0.0.0-2_amd64.deb ...
Unpacking oracle-instantclient18.3-basic (18.3.0.0.0-2) ...
Setting up oracle-instantclient18.3-basic (18.3.0.0.0-2) ...
Processing triggers for libc-bin (2.27-3ubuntu1) ...
	dpkg --no-force-overwrite -i oracle-instantclient18.3-odbc_18.3.0.0.0-2_amd64.deb
Selecting previously unselected package oracle-instantclient18.3-odbc.
(Reading database ... 25926 files and directories currently installed.)
Preparing to unpack oracle-instantclient18.3-odbc_18.3.0.0.0-2_amd64.deb ...
Unpacking oracle-instantclient18.3-odbc (18.3.0.0.0-2) ...
Setting up oracle-instantclient18.3-odbc (18.3.0.0.0-2) ...
Processing triggers for libc-bin (2.27-3ubuntu1) ...
```
3. Tested that pyodbc could see the Oracle driver: `python3 -c "import pyodbc; print(pyodbc.drivers())"`:
```
['Oracle Driver 18.3']
```
4. Testing that we can actually use the driver: `python -c 'import pyodbc; pyodbc.connect("DRIVER={Oracle Driver 18.3};DBQ=<server name>:<port>/<DB name>;UID=<DB username>;PWD=<DB password>")' && echo $?`:
```
0
```