### PR TITLE
Fix jupyterlab_git

### DIFF
--- a/base/drivers/python/jupyter/jupyter_additions.sh
+++ b/base/drivers/python/jupyter/jupyter_additions.sh
@@ -18,7 +18,8 @@ jupyter labextension enable @jupyterlab/hub-extension
 
 # jupyterlab-git
 jupyter labextension install @jupyterlab/git
-jupyter labextension enable @jupyterlab/git
+pip install jupyterlab-git
+jupyter serverextension enable --py jupyterlab_git --sys-prefix
 
 # jupyterlab-dicovery
 python3 -m pip install jupyterlab-discovery


### PR DESCRIPTION
# Problem
Jupyterlab git extension currently doesn't work on this image

# Diagnosis
The jupyterlab-git pypi package is not installed. 
The jupyter git serverextension  is not enabled
The jupyter git serverextension is not installed in sys mode

# Solution
Install jupyterlab-git pypi package
Install jupyter git server extension in sys mode

# Caveat
I've removed the `enable` command for labextension. It isn't in the install commands on the jupyterlab-git README. If the newly built image doesn't have functional git extension then I'd suggest patching it in again.